### PR TITLE
Update generate_tags_hter.py

### DIFF
--- a/corpus_generation/generate_tags_hter.py
+++ b/corpus_generation/generate_tags_hter.py
@@ -6,7 +6,6 @@ import argparse
 
 sys.path.insert(0, 'tools')
 
-from tools.alltokenisers import tokenize
 from tools.preprocess import truecase
 from tools.aligners import align_simaligner as align
 from tools.generate_BAD_tags import generate_bad_ok_tags
@@ -26,7 +25,7 @@ def parse_args():
     parser.add_argument('--gaps', dest='gaps', action='store_true')
     parser.add_argument('--delete', type=str, default = 'none')
     
-    parser.set_defaults(token=True)
+    parser.set_defaults(token=False)
     parser.set_defaults(truecase=False)
     parser.set_defaults(gaps=False)
     
@@ -39,6 +38,7 @@ def main(args):
     pe = args.pe  
     path = os.path.dirname(os.path.abspath(src))
     if args.token:
+        from tools.alltokenisers import tokenize
         tok_src = tokenize(args.src_lang, src)
         tok_mt = tokenize(args.tgt_lang, mt)
         tok_pe = tokenize(args.tgt_lang, pe)
@@ -78,10 +78,7 @@ def main(args):
     hter = src.rsplit('.')[0]+'.hter'
     print("ALIGNED MT PE")
 
-    if args.gaps:
-        generate_bad_ok_tags(tok_tc_src, tok_tc_mt, tok_tc_pe, mt_pe_align, src_pe_align, 'normal', src_tags, tgt_tags)
-    else:
-        generate_bad_ok_tags(tok_tc_src, tok_tc_mt, tok_tc_pe, mt_pe_align, src_pe_align, 'normal', src_tags, tgt_tags, False, args.delete)
+    generate_bad_ok_tags(tok_tc_src, tok_tc_mt, tok_tc_pe, mt_pe_align, src_pe_align, 'normal', src_tags, tgt_tags, args.gaps, args.delete)
     params = ["bash ./tools/tercom.sh " +  tok_tc_mt+ " " + tok_tc_pe + " " + tercom + " "+ mt_pe_align + " true"]
     p2 = subprocess.Popen(params, shell=True)
     p2.wait() 


### PR DESCRIPTION
Suggesting some small fixes.

- The default value for the `token` flag should be `False`, and be set when the flag is present (like `truecase` and `gaps`).
- The imports needed for the `alltokenisers` should only be done in the case where the `token` flag is set.
- `generate_bad_ok_tags` didn't have all the necessary arguments to be called when `gaps` was set.